### PR TITLE
fixed updating and deleting Lucene documents

### DIFF
--- a/src/LeadPipe.Net.Lucene/SearchIndexUpdater.cs
+++ b/src/LeadPipe.Net.Lucene/SearchIndexUpdater.cs
@@ -93,7 +93,7 @@ namespace LeadPipe.Net.Lucene
         /// <param name="indexWriter">The index writer.</param>
         private static void DeleteEntityFromIndex(TSearchData searchData, IndexWriter indexWriter)
         {
-            var searchQuery = new TermQuery(new Term("Key", searchData.Key));
+            var searchQuery = new TermQuery(new Term("key", searchData.Key));
 
             indexWriter.DeleteDocuments(searchQuery);
         }


### PR DESCRIPTION
I wasn't able to get UpdateIndex method to work. It was always adding a new document even though key was the same. I am not sure why but if "Key" is not lowercase "key" it simply doesn't delete any documents. If I make delete query on some other field it work and doesn't care about casing. Weird. 